### PR TITLE
PostgreSQL 循环执行系统命令，每次执行完命令输出到控制台后，清空数据表中的内容

### DIFF
--- a/pac/postgre_cve_2019_9193.go
+++ b/pac/postgre_cve_2019_9193.go
@@ -72,5 +72,10 @@ func cve_2019_9193_console(conn *sql.DB) {
 		if err != nil {
 			Err(err)
 		}
+		// 执行完命令输出到控制台后，清空数据表中的内容
+		_, err = postgrecmd("DELETE FROM cmd_exec;", conn)
+		if err != nil {
+			Err(err)
+		}
 	}
 }


### PR DESCRIPTION
很多时候需要执行很多系统命令，以进一步利用

原版本：
每次执行系统命令后，没有删除上次执行命令时存入数据表中的记录
![图片](https://github.com/Hel10-Web/Databasetools/assets/34545908/dde795b0-7b90-4aac-b426-383e76a1f19c)

优化后：
PostgreSQL 循环执行系统命令，每次执行完命令输出到控制台后，清空数据表中的内容：
![图片](https://github.com/Hel10-Web/Databasetools/assets/34545908/94625f22-5ee8-456d-90b8-3d54809013fd)
